### PR TITLE
chore: hide api key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,6 +1,8 @@
 // variaveis e selecao de elementos
 
-const apiKey = "99292d8c04554b4fdd0d7f6290bcd9b0";
+const fs = require('fs');
+const config = JSON.parse(fs.readFileSync('config.json'));
+const apiKey = config.apiKey;
 const apiCountryURL = "https://countryflagsapi.com/png/";
 const apiUnsplash = "https://source.unsplash.com/1600x900/?";
 


### PR DESCRIPTION
I added a config.jason file with my API key, created a .gitinore file to hide this json file, used the node fs library to import the json object and used the parse method to convert it to a string and integrate the apikey into my code.